### PR TITLE
[#163591232] Backport CAPI pagination fix

### DIFF
--- a/internal/auth/capi_client.go
+++ b/internal/auth/capi_client.go
@@ -109,6 +109,7 @@ func (c *CAPIClient) AvailableSourceIDs(authToken string) []string {
 		return nil
 	}
 
+	preserveScheme, preserveHost := req.URL.Scheme, req.URL.Host
 	for {
 		resources, nextPageURL, err := c.doResourceRequest(req, authToken, c.storeAppsLatency)
 		if err != nil {
@@ -123,7 +124,9 @@ func (c *CAPIClient) AvailableSourceIDs(authToken string) []string {
 		if nextPageURL == nil {
 			break
 		}
+
 		req.URL = nextPageURL
+		req.URL.Scheme, req.URL.Host = preserveScheme, preserveHost
 	}
 
 	req, err = http.NewRequest(http.MethodGet, c.externalCapi+"/v3/service_instances", nil)

--- a/internal/auth/capi_client.go
+++ b/internal/auth/capi_client.go
@@ -109,7 +109,6 @@ func (c *CAPIClient) AvailableSourceIDs(authToken string) []string {
 		return nil
 	}
 
-	preserveScheme, preserveHost := req.URL.Scheme, req.URL.Host
 	for {
 		resources, nextPageURL, err := c.doResourceRequest(req, authToken, c.storeAppsLatency)
 		if err != nil {
@@ -126,7 +125,6 @@ func (c *CAPIClient) AvailableSourceIDs(authToken string) []string {
 		}
 
 		req.URL = nextPageURL
-		req.URL.Scheme, req.URL.Host = preserveScheme, preserveHost
 	}
 
 	req, err = http.NewRequest(http.MethodGet, c.externalCapi+"/v3/service_instances", nil)
@@ -237,6 +235,8 @@ func (c *CAPIClient) doResourceRequest(req *http.Request, authToken string, metr
 		if err != nil {
 			return apps.Resources, nextPageURL, fmt.Errorf("failed to parse URL %s: %s", apps.Pagination.Next.Href, err)
 		}
+		// Ensure we continue to use the external CAPI hostname
+		nextPageURL.Scheme, nextPageURL.Host = req.URL.Scheme, req.URL.Host
 	}
 
 	return apps.Resources, nextPageURL, nil

--- a/internal/auth/capi_client_test.go
+++ b/internal/auth/capi_client_test.go
@@ -150,11 +150,12 @@ var _ = Describe("CAPIClient", func() {
 		It("iterates through all pages returned by /v3/apps", func() {
 			tc := setup()
 
+			By("replacing the scheme and host to match original requests' capi addr")
 			tc.capiClient.resps = []response{
 				{status: http.StatusOK, body: []byte(`{
                   "pagination": {
                     "next": {
-                      "href": "https://external.capi.com/v3/apps?page=2&per_page=1"
+                      "href": "https://thisismycapi.com/v3/apps?page=2&per_page=1"
                     }
                   },
                   "resources": [
@@ -172,10 +173,8 @@ var _ = Describe("CAPIClient", func() {
 			sourceIDs := tc.client.AvailableSourceIDs("some-token")
 			Expect(tc.capiClient.requests).To(HaveLen(3))
 			secondPageReq := tc.capiClient.requests[1]
-			Expect(secondPageReq.URL.Path).To(Equal("/v3/apps"))
-			Expect(secondPageReq.URL.Query().Get("page")).To(Equal("2"))
-			Expect(secondPageReq.URL.Query().Get("per_page")).To(Equal("1"))
 
+			Expect(secondPageReq.URL.String()).To(Equal("http://external.capi.com/v3/apps?page=2&per_page=1"))
 			Expect(sourceIDs).To(ConsistOf("app-1", "app-2"))
 		})
 

--- a/internal/auth/capi_client_test.go
+++ b/internal/auth/capi_client_test.go
@@ -155,7 +155,7 @@ var _ = Describe("CAPIClient", func() {
 				{status: http.StatusOK, body: []byte(`{
                   "pagination": {
                     "next": {
-                      "href": "https://thisismycapi.com/v3/apps?page=2&per_page=1"
+                      "href": "https://internal.capi.com/v3/apps?page=2&per_page=1"
                     }
                   },
                   "resources": [
@@ -186,7 +186,7 @@ var _ = Describe("CAPIClient", func() {
 				{status: http.StatusOK, body: []byte(`{
                   "pagination": {
                     "next": {
-                      "href": "https://external.capi.com/v3/service_instances?page=2&per_page=2"
+                      "href": "https://internal.capi.com/v3/service_instances?page=2&per_page=2"
                     }
                   },
                   "resources": [
@@ -203,9 +203,7 @@ var _ = Describe("CAPIClient", func() {
 			sourceIDs := tc.client.AvailableSourceIDs("some-token")
 			Expect(tc.capiClient.requests).To(HaveLen(3))
 			secondPageReq := tc.capiClient.requests[2]
-			Expect(secondPageReq.URL.Path).To(Equal("/v3/service_instances"))
-			Expect(secondPageReq.URL.Query().Get("page")).To(Equal("2"))
-			Expect(secondPageReq.URL.Query().Get("per_page")).To(Equal("2"))
+			Expect(secondPageReq.URL.String()).To(Equal("http://external.capi.com/v3/service_instances?page=2&per_page=2"))
 
 			Expect(sourceIDs).To(ConsistOf("service-1", "service-2", "service-3"))
 		})
@@ -327,7 +325,7 @@ var _ = Describe("CAPIClient", func() {
 				{status: http.StatusOK, body: []byte(`{
                   "pagination": {
                     "next": {
-                      "href": "https://external.capi.com/v3/apps?page=2&per_page=2"
+                      "href": "https://internal.capi.com/v3/apps?page=2&per_page=2"
                     }
                   },
                   "resources": [
@@ -346,9 +344,7 @@ var _ = Describe("CAPIClient", func() {
 
 			Expect(tc.capiClient.requests).To(HaveLen(2))
 			secondPageReq := tc.capiClient.requests[1]
-			Expect(secondPageReq.URL.Path).To(Equal("/v3/apps"))
-			Expect(secondPageReq.URL.Query().Get("page")).To(Equal("2"))
-			Expect(secondPageReq.URL.Query().Get("per_page")).To(Equal("2"))
+			Expect(secondPageReq.URL.String()).To(Equal("http://external.capi.com/v3/apps?page=2&per_page=2"))
 			Expect(sourceIds).To(HaveKeyWithValue("app-name", ConsistOf("app-0", "app-1", "app-2")))
 		})
 


### PR DESCRIPTION
## What

This backports the fix for the [CAPI pagination issue](https://github.com/cloudfoundry/log-cache/issues/98) to v2.0.2 (that we're currently running). We've also extended the fix to be more complete and cover all potentially paginated requests made to CAPI.

## How to review

* Review along with other PRs https://github.com/alphagov/paas-log-cache-release/pull/1 and https://github.com/alphagov/paas-cf/pull/1744

## Who can review

Not me.